### PR TITLE
Deprecate Crush for Removal

### DIFF
--- a/src/main/java/com/github/automaton/automata/Automaton.java
+++ b/src/main/java/com/github/automaton/automata/Automaton.java
@@ -136,7 +136,10 @@ public class Automaton implements AutoCloseable {
     /** The pruned U-Structure */
     PRUNED_U_STRUCTURE((byte) 2, PrunedUStructure.class),
 
-    /** A pruned U-Structure after being 'crushed' with respect to a given controller */
+    /**
+     * A pruned U-Structure after being 'crushed' with respect to a given controller 
+     */
+    @Deprecated(forRemoval = true)
     CRUSH((byte) 3, Crush.class);
 
     // Private variables

--- a/src/main/java/com/github/automaton/automata/Crush.java
+++ b/src/main/java/com/github/automaton/automata/Crush.java
@@ -13,7 +13,11 @@ import java.io.*;
  * Representation of a Crush structure.
  *
  * @author Micah Stairs
+ * 
+ * @deprecated Crush is too restrictive in terms of its capabilities, and is subject to removal. See
+ * <a href="https://github.com/Summer2023SHY/Automata/issues/28">Automata#28</a> for more information.
  */
+@Deprecated(forRemoval = true)
 public class Crush extends PrunedUStructure {
 
     /* ENUM */

--- a/src/main/java/com/github/automaton/automata/UStructure.java
+++ b/src/main/java/com/github/automaton/automata/UStructure.java
@@ -531,7 +531,11 @@ public class UStructure extends Automaton {
    * @throws DoesNotSatisfyObservabilityException If the system does not satisfy observability, meaning
    *                                              that there are no feasible protocols that satisfy the
    *                                              control problem.
+   * 
+   * @deprecated Operations for Nash equilibria depend on {@link Crush}. As {@link Crush} is deprecated
+   * and subject to removal, all Nash equilibria operations are deprecated.
    **/
+  @Deprecated
   public List<Set<NashCommunicationData>> findNashEquilibria(Crush.CombiningCosts combiningCostsMethod)
                                                              throws DoesNotSatisfyObservabilityException {
 
@@ -552,7 +556,11 @@ public class UStructure extends Automaton {
    * @param feasibleProtocols                     The list of feasible protocols to consider
    *                                              NOTE: They must all solve the control problem
    * @return                                      The list of Nash equilibria
+   * 
+   * @deprecated Operations for Nash equilibria depend on {@link Crush}. As {@link Crush} is deprecated
+   * and subject to removal, all Nash equilibria operations are deprecated.
    **/
+  @Deprecated
   public List<Set<NashCommunicationData>> findNashEquilibria(Crush.CombiningCosts combiningCostsMethod,
                                                              List<Set<NashCommunicationData>> feasibleProtocols) {
 
@@ -648,7 +656,10 @@ public class UStructure extends Automaton {
    *                              with the combined costs (if null, then a HashMap will simply not be populated)
    * @param combiningCostsMethod  The method used to combine communication costs (can be null if there are no communications)
    * @return                      The crush
+   * 
+   * @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
    **/
+  @Deprecated(forRemoval = true)
   public Crush crush(File newHeaderFile,
                      File newBodyFile,
                      int indexOfController,
@@ -824,7 +835,10 @@ public class UStructure extends Automaton {
    * @param newBodyFile           The file where the body should be stored
    * @param indexOfController     The index of the controller in which the crush is taken with respect to (1-based)
    * @return                      The crush
+   * 
+   * @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
    **/
+  @Deprecated(forRemoval = true)
   public Crush crush(File newHeaderFile,
                      File newBodyFile,
                      int indexOfController) {
@@ -955,7 +969,10 @@ public class UStructure extends Automaton {
    * Find the Shapley values for each coalition.
    * NOTE: This can also be used to find the Myerson values once the U-Structure has been pruned.
    * @return  The mapping between the coalitions and their respective values (or null if there were violations)
+   * 
+   * @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
    **/
+  @Deprecated(forRemoval = true)
   public Map<Set<Integer>, Integer> findShapleyValues() {
 
     // Ensure that there are no violations
@@ -1641,7 +1658,10 @@ public class UStructure extends Automaton {
    *                                    will be created (since those objects could be referenced in other
    *                                    protocols, and we do not want to interfere with them)
    * @param combiningCostsMethod  The method in which the communications are being combined
+   * 
+   * @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
    **/
+  @Deprecated(forRemoval = true)
   public void combineCommunicationCosts(Set<NashCommunicationData> feasibleProtocol,
                                         Crush.CombiningCosts combiningCostsMethod) {
 
@@ -1688,7 +1708,10 @@ public class UStructure extends Automaton {
    * @param setOfStates     The set of states which are being crushed
    * @param isInitialState  Whether or not this crushed state is the initial state
    * @param id              The ID of the crushed state
+   * 
+   * @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
    **/
+  @Deprecated(forRemoval = true)
   private void addStateToCrush(Crush crush, Set<Long> setOfStates, boolean isInitialState, long id) {
 
     // Create a label for this state

--- a/src/main/java/com/github/automaton/gui/ChooseCommunicatorsForMyersonPrompt.java
+++ b/src/main/java/com/github/automaton/gui/ChooseCommunicatorsForMyersonPrompt.java
@@ -41,6 +41,7 @@ public class ChooseCommunicatorsForMyersonPrompt extends ChooseSendersAndRecieve
     /* OVERIDDEN METHOD */
   /** {@inheritDoc} */
   @Override
+  @SuppressWarnings("removal")
   protected boolean performAction() {
 
     Set<CommunicationData> protocol = getProtocol();
@@ -62,6 +63,7 @@ public class ChooseCommunicatorsForMyersonPrompt extends ChooseSendersAndRecieve
     PrunedUStructure prunedUStructure = uStructure.applyProtocol(getProtocol(), null, null, true);
 
     // Display Myerson values
+    // TODO: Handle use of deprecated method
     new ShapleyValuesOutput(gui, prunedUStructure, "Myerson Values", "Myerson values by controller:", "Myerson values by coalition:");
 
     return true;

--- a/src/main/java/com/github/automaton/gui/ChooseCommunicatorsForNashPrompt.java
+++ b/src/main/java/com/github/automaton/gui/ChooseCommunicatorsForNashPrompt.java
@@ -20,7 +20,11 @@ import com.github.automaton.automata.UStructure;
  * once they have selected senders and recievers.
  *
  * @author Micah Stairs
+ * 
+ * @deprecated Operations for Nash equilibria depend on {@link Crush}. As {@link Crush} is deprecated
+   * and subject to removal, all Nash equilibria operations are deprecated.
  */
+@Deprecated
 public class ChooseCommunicatorsForNashPrompt extends ChooseSendersAndRecieversPrompt {
 
     /* CONSTRUCTOR */

--- a/src/main/java/com/github/automaton/gui/JDec.java
+++ b/src/main/java/com/github/automaton/gui/JDec.java
@@ -33,14 +33,7 @@ import org.apache.batik.swing.svg.JSVGComponent;
 import org.w3c.dom.*;
 import org.xml.sax.*;
 
-import com.github.automaton.automata.Automaton;
-import com.github.automaton.automata.CommunicationData;
-import com.github.automaton.automata.Crush;
-import com.github.automaton.automata.IncompatibleAutomataException;
-import com.github.automaton.automata.MissingOrCorruptBodyFileException;
-import com.github.automaton.automata.OperationFailedException;
-import com.github.automaton.automata.PrunedUStructure;
-import com.github.automaton.automata.UStructure;
+import com.github.automaton.automata.*;
 import com.github.automaton.gui.util.*;
 
 /**
@@ -478,6 +471,7 @@ public class JDec extends JFrame implements ActionListener {
    * This method handles all of the actions triggered when the user interacts with the main menu.
    * @param event The triggered event
    **/
+  @SuppressWarnings({"deprecation", "removal"})
   public void actionPerformed(ActionEvent event) {
 
     int index = tabbedPane.getSelectedIndex();
@@ -721,6 +715,8 @@ public class JDec extends JFrame implements ActionListener {
 
       case "Crush":
 
+        //TODO: Get rid of Crush operations
+
         UStructure uStructure = ((UStructure) tab.automaton);
 
         if (uStructure.hasViolations()) {
@@ -834,7 +830,7 @@ public class JDec extends JFrame implements ActionListener {
         break;
 
       case "Nash":
-
+        // TODO: Handle use of deprecated method
         uStructure = ((UStructure) tab.automaton);
 
         if (uStructure.hasSelfLoop(uStructure.getPotentialAndNashCommunications()))
@@ -1058,6 +1054,7 @@ public class JDec extends JFrame implements ActionListener {
   /**
    * Generate an automaton using the entered GUI input code.
    **/
+  @SuppressWarnings("removal")
   private void generateAutomatonButtonPressed() {
 
     // Get the current tab
@@ -1113,7 +1110,7 @@ public class JDec extends JFrame implements ActionListener {
         break;
 
       case CRUSH:
-
+        // TODO: Get rid of Crush operations
         nControllers = (Integer) tabs.get(tabbedPane.getSelectedIndex()).controllerInput.getValue();
         tab.automaton = AutomatonGenerator.generateFromGUICode(
           new Crush(tab.headerFile, tab.bodyFile, nControllers),
@@ -1239,6 +1236,7 @@ public class JDec extends JFrame implements ActionListener {
    * NOTE: A loading bar is displayed to keep track of the progress.
    * @param index The tab's index
    **/
+  @SuppressWarnings("removal")
   private void refresh(final int index) {
       
     setBusyCursor(true);
@@ -1272,6 +1270,7 @@ public class JDec extends JFrame implements ActionListener {
             break;
 
           case CRUSH:
+            // TODO: Get rid of Crush operations
             tab.automaton = new Crush(tab.headerFile, tab.bodyFile);
             break;
 

--- a/src/main/java/com/github/automaton/gui/NashInfoForCrushPrompt.java
+++ b/src/main/java/com/github/automaton/gui/NashInfoForCrushPrompt.java
@@ -17,7 +17,10 @@ import com.github.automaton.automata.Crush;
  * the cost and probability values for the Nash communications.
  *
  * @author Micah Stairs
+ * 
+* @deprecated Crush is too restrictive in terms of its capabilities, and all operations related to it are subject to removal.
  */
+@Deprecated(forRemoval = true)
 public class NashInfoForCrushPrompt extends NashInformationPrompt {
 
     /* CONSTRUCTOR */

--- a/src/main/java/com/github/automaton/gui/NashInfoForNashEquilibriaPrompt.java
+++ b/src/main/java/com/github/automaton/gui/NashInfoForNashEquilibriaPrompt.java
@@ -13,7 +13,11 @@ import javax.swing.*;
  * choosing the cost and probability values for the Nash communications.
  *
  * @author Micah Stairs
+ * 
+ * @deprecated Operations for Nash equilibria depend on {@link Crush}. As {@link Crush} is deprecated
+ * and subject to removal, all Nash equilibria operations are deprecated.
  */
+@Deprecated
 public class NashInfoForNashEquilibriaPrompt extends NashInformationPrompt {
 
     /* CONSTRUCTOR */

--- a/src/main/java/com/github/automaton/gui/ShapleyValuesOutput.java
+++ b/src/main/java/com/github/automaton/gui/ShapleyValuesOutput.java
@@ -19,7 +19,12 @@ import com.github.automaton.automata.UStructure;
  * and each controller in a popup.
  *
  * @author Micah Stairs
+ * 
+ * @deprecated Data being displayed through this class depends on the
+ * deprecated {@link UStructure#findShapleyValues()} method, and thus, this
+ * class is also deprecated and subject to removal.
  */
+@Deprecated(forRemoval = true)
 public class ShapleyValuesOutput extends JDialog {
 
     /* INSTANCE VARIABLES */

--- a/src/test/java/com/github/automaton/TestAutomata.java
+++ b/src/test/java/com/github/automaton/TestAutomata.java
@@ -19,6 +19,7 @@ import com.github.automaton.automata.UStructure;
 import com.github.automaton.automata.util.ByteManipulator;
 import com.github.automaton.gui.util.AutomatonGenerator;
 
+@SuppressWarnings({"deprecation", "removal"})
 public class TestAutomata {
 
   // Colored output makes it more readable (doesn't work on all operating systems)


### PR DESCRIPTION
See #28.

This PR marks `Crush` and all related methods as deprecated.