### PR TITLE
Restore Some macOS-specific UI Code

### DIFF
--- a/src/main/java/com/github/automaton/gui/JDec.java
+++ b/src/main/java/com/github/automaton/gui/JDec.java
@@ -144,6 +144,21 @@ public class JDec extends JFrame implements ActionListener {
    **/  
   public static void main(String[] args) {
     
+    if (SystemUtils.IS_OS_MAC) {
+      // macOS-specific UI tinkering
+      try {
+        // Use system menu bar
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+        // Set application name
+        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "JDec");
+        // Associate cmd+Q with the our window handler
+        System.setProperty("apple.eawt.quitStrategy", "CLOSE_ALL_WINDOWS");
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+      } catch (ReflectiveOperationException | UnsupportedLookAndFeelException e) {
+        logger.catching(e);
+      }
+    }
+
     // Start the application  
     new JDec();
   
@@ -158,7 +173,10 @@ public class JDec extends JFrame implements ActionListener {
 
     URL iconUrl = getResourceURL("icon.png");
     ImageIcon icon = new ImageIcon(iconUrl);
-    setIconImage(icon.getImage());
+    if (SystemUtils.IS_OS_MAC) {
+      Taskbar.getTaskbar().setIconImage(icon.getImage());
+    } else
+      setIconImage(icon.getImage());
 
     setMinimumSize(new Dimension(1280, 720));
 


### PR DESCRIPTION
Back in #2 all macOS-specific GUI code was removed in favor of cross-platform compatibility. This PR restores some of the removed code in a cross-platform compatible way, i.e., the restored code should not cause compilation errors.